### PR TITLE
specify ascii encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup (name = "ghalton",
        author_email = "f.derainville@gmail.com",
        license = "LICENSE.txt",
        description = "Generalized Halton number generator",
-       long_description = open("README.md").read(),
+       long_description = open("README.md",encoding="utf-8").read(),
        url='https://github.com/fmder/ghalton',
        download_url = "https://github.com/fmder/ghalton/tarball/master#egg=ghalton-%s" % version,
        classifiers=[


### PR DESCRIPTION
<img width="886" alt="screen shot 2018-07-23 at 5 03 20 am" src="https://user-images.githubusercontent.com/25622540/43067844-a0bcd5d2-8e36-11e8-9cf9-296f09d2569e.png">

Hi, I meet this problem when trying to install ghalton on my mac, and then solved it by specifying the encoding in setup.py. 